### PR TITLE
Free voxel_resource pool on _exit_tree() to plug queue_free() collision-pool leak (fixes #77)

### DIFF
--- a/addons/VoxelDestruction/Nodes/voxel_object.gd
+++ b/addons/VoxelDestruction/Nodes/voxel_object.gd
@@ -1148,3 +1148,10 @@ func _exit_tree():
 		_voxel_server.total_active_voxels -= voxel_resource.positions_dict.size()
 		for key in _collision_shapes:
 			_voxel_server.shape_count -= _collision_shapes[key].size()
+		# Free orphaned collision/debris pool nodes on the queue_free() path.
+		# _end_of_life() calls _clear() but _exit_tree() does not; partially-carved
+		# objects freed via queue_free() leak ~33 CollisionShape3D per object.
+		# Guard prevents double-free on the _end_of_life(end_of_life=2) path,
+		# which already calls _clear() before queue_free().
+		if voxel_resource != null and not voxel_resource._cleared:
+			voxel_resource._clear()


### PR DESCRIPTION
Fixes #77.

### What changed
Append a 2-line guarded call to `voxel_resource._clear()` at the bottom of `voxel_object._exit_tree()`, so the collision/debris pools are freed on the `queue_free()` path. `_end_of_life()` already calls `_clear()`; `_exit_tree()` did not, so any `VoxelObject` freed externally leaked its pools.

```gdscript
if voxel_resource != null and not voxel_resource._cleared:
    voxel_resource._clear()
```

The `_cleared` guard prevents a double-free on the `_end_of_life(end_of_life=2)` path, which calls `_clear()` then `queue_free()` (which triggers `_exit_tree()`). `voxel_resource_base._clear()` sets `_cleared = true` as its first statement, so the guard is sufficient. `_clear()` itself uses `is_instance_valid()` on each pool node, so it's safe against nodes already freed elsewhere.

### Verified impact

Measured on Godot 4.6 (Forward+ / Jolt), Windows 11, our project's test suite (109 suites / 339 cases). Only variable: presence of the patch.

| Metric | Without patch | With patch | Delta |
|---|---|---|---|
| Total orphan nodes (whole suite) | 15,524 | 1,348 | **-91%** |
| Single suite (`test_wave_survived_win_emit`) | ~13,867 | 137 | **-99%** |
| Test failures (regression check) | 11 (pre-existing) | 11 (identical) | **0 new** |

Corpse fracture, carving, and debris spawn all behave identically — patch is additive and only frees what would otherwise leak.

### Notes
Happy to add a regression test if you have a preferred test pattern. As mentioned in the issue, there are two pre-existing concerns in the same function (un-null-guarded access to `_voxel_server` and `voxel_resource.positions_dict`); I left those alone to keep this PR focused, but happy to file separately if useful.