### PR TITLE
Guard _apply_damage_results against dead multimesh (fixes #79)

### DIFF
--- a/addons/VoxelDestruction/Nodes/voxel_object.gd
+++ b/addons/VoxelDestruction/Nodes/voxel_object.gd
@@ -416,6 +416,12 @@ func _damage_voxel(voxel: int, voxel_positions: PackedVector3Array, global_voxel
 
 
 func _apply_damage_results(damager: VoxelDamager, damage_results: Array) -> void:
+	# Drop late-arriving damage tasks against a dead multimesh. _end_of_life()
+	# may have set instance_count = 0 and/or nulled multimesh while
+	# WorkerThreadPool tasks were still in flight; applying them against the
+	# dead multimesh produces "Instance index out of bounds" spam.
+	if multimesh == null or multimesh.instance_count == 0:
+		return
 	voxel_resource.buffer("positions")
 	voxel_resource.buffer("positions_dict")
 	voxel_resource.buffer("chunks")


### PR DESCRIPTION
Fixes #79.

### What changed
Drop late-arriving `WorkerThreadPool` damage tasks at the top of `_apply_damage_results()` when the `VoxelObject` has already entered `_end_of_life()`.

```gdscript
func _apply_damage_results(damager: VoxelDamager, damage_results: Array) -> void:
    if multimesh == null or multimesh.instance_count == 0:
        return
    ...
```

`_end_of_life()` sets `multimesh.instance_count = 0` and (on `end_of_life=1`) nulls `multimesh`. Without this guard, any damage task still pending in `WorkerThreadPool` when end-of-life ran is applied against the dead multimesh on the next `_physics_process` tick and produces "Instance index out of bounds" + "p_count > instance_count" spam from `voxel_multi_mesh.gd`'s `set_instance_visibility()` and `voxel_set_instance_*()` (see #79 for full traces).

### Why this shape
This is the minimal upstream-friendly fix. A stricter variant would also drain or cancel `_damage_tasks` inside `_end_of_life()`. Happy to switch shapes if you prefer that — let me know and I'll update the PR.

### Verified
- Godot 4.6 (Forward+ / Jolt), Windows 11, our test suite (109 suites / 339 cases).
- Reproduces deterministically in `test_mission_win_emits_exactly_once` where a wave of enemies dies in a single tick — late damage results land after `_end_of_life()`.
- With the guard: error stream clean; corpse fracture, carving, debris all behave identically.

### Notes
Same class of issue as #77 (#78) — end-of-life / external-teardown paths bypassing addon-internal cleanup. Happy to add a regression test if you have a preferred pattern.